### PR TITLE
Fix production middleware invocation error

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -15,7 +15,7 @@ export const {
   signOut,
 } = NextAuth({
   pages: {
-    signIn: "/auth/login",
+    signIn: "/auth/signin",
     error: "/auth/error",
   },
   events: {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -51,5 +51,6 @@ export default auth(
 );
 
 export const config = {
+  runtime: "nodejs",
   matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
 };


### PR DESCRIPTION
## Résumé

- exécute le middleware Next.js dans le runtime Node.js
- corrige la route de connexion Auth.js vers `/auth/signin`

## Cause

Le middleware importe la configuration Auth.js, qui charge des dépendances serveur telles que Drizzle, Neon et `bcrypt`. Le runtime Edge utilisé par défaut pouvait échouer à l’invocation en production avec `MIDDLEWARE_INVOCATION_FAILED`.

## Impact

Le middleware dispose désormais des APIs Node.js requises et les redirections Auth.js pointent vers la route de connexion existante.

## Validation

- `pnpm build`
- vérification de l’artefact Next.js : `/_middleware` est configuré avec `runtime: "nodejs"`
- `git diff --check`
