### PR TITLE
Isolate database authentication from middleware

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,10 +1,6 @@
 import { NextAuthConfig } from "next-auth";
-import Credentials from "next-auth/providers/credentials";
 import Github from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
-import { LoginSchema } from "./schemas";
-import { getUserByEmail } from "./server/queries/users";
-import bcrypt from "bcryptjs";
 
 export default {
   providers: [
@@ -15,25 +11,6 @@ export default {
     Github({
       clientId: process.env.AUTH_GITHUB_ID,
       clientSecret: process.env.AUTH_GITHUB_SECRET,
-    }),
-    Credentials({
-      async authorize(credentials) {
-        const validatedFields = LoginSchema.safeParse(credentials);
-
-        if (validatedFields.success) {
-          const { email, password } = validatedFields.data;
-
-          const user = await getUserByEmail(email);
-
-          if (!user || !user.password) return null;
-
-          const passwordMatch = await bcrypt.compare(password, user.password);
-
-          if (passwordMatch) return user;
-        }
-
-        return null;
-      },
     }),
   ],
 } satisfies NextAuthConfig;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,12 +1,15 @@
 import NextAuth from "next-auth";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
+import Credentials from "next-auth/providers/credentials";
+import bcrypt from "bcryptjs";
 import { db } from "./server/db";
 
-import { getUserById } from "./server/queries/users";
+import { getUserByEmail, getUserById } from "./server/queries/users";
 import authConfig from "~/auth.config";
 import { users } from "./server/db/schema";
 import { eq } from "drizzle-orm";
 import { getAccountByUserId } from "./server/queries/account";
+import { LoginSchema } from "./schemas";
 
 export const {
   handlers: { GET, POST },
@@ -14,6 +17,29 @@ export const {
   signIn,
   signOut,
 } = NextAuth({
+  ...authConfig,
+  providers: [
+    ...authConfig.providers,
+    Credentials({
+      async authorize(credentials) {
+        const validatedFields = LoginSchema.safeParse(credentials);
+
+        if (validatedFields.success) {
+          const { email, password } = validatedFields.data;
+
+          const user = await getUserByEmail(email);
+
+          if (!user || !user.password) return null;
+
+          const passwordMatch = await bcrypt.compare(password, user.password);
+
+          if (passwordMatch) return user;
+        }
+
+        return null;
+      },
+    }),
+  ],
   pages: {
     signIn: "/auth/signin",
     error: "/auth/error",
@@ -74,5 +100,4 @@ export const {
   },
   adapter: DrizzleAdapter(db),
   session: { strategy: "jwt" },
-  ...authConfig,
 });


### PR DESCRIPTION
## Résumé

- conserve la configuration OAuth légère dans `auth.config.ts`
- déplace le provider Credentials, `bcrypt` et les requêtes utilisateur dans `auth.ts`
- empêche le middleware d'initialiser Neon au chargement

## Cause

Le middleware instancie Auth.js à partir de `auth.config.ts`. Cette configuration importait auparavant le provider Credentials, qui importait lui-même les requêtes utilisateur et le client Neon. Par conséquent, chaque invocation du middleware dépendait de `DATABASE_URL`, y compris pour les routes publiques et les simples redirections.

## Audit Vercel

- `DATABASE_URL` est déclarée dans les scopes Production et Preview
- le dernier déploiement Production répond correctement sur `/`, `/categories` et `/api/auth/session`
- aucune nouvelle erreur de fonction n'a été observée sur ce déploiement

## Impact

Le middleware ne dépend plus de la connexion à la base de données. Les opérations Credentials et les callbacks qui interrogent la base restent exécutés côté serveur via `auth.ts`.

## Validation

- `pnpm build`
- `git diff --check`
- vérification du bundle : aucune occurrence de `DATABASE_URL` ou `bcrypt` dans `.next/server/middleware.js`
